### PR TITLE
Remove Datadog dependency from latam_logger

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    latam_logger (0.1.0)
+    latam_logger (0.2.0)
 
 GEM
   remote: https://rubygems.org/

--- a/latam_logger.gemspec
+++ b/latam_logger.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.add_dependency('ddtrace')
 end

--- a/lib/latam_logger/log/logging.rb
+++ b/lib/latam_logger/log/logging.rb
@@ -11,16 +11,11 @@ module LatamLogger
       def initialize
         @logger = Logger.new(ENV['LATAM_LOGGER_PATH_FILE'] || STDOUT)
         @logger.formatter = method(:format_log)
-        Datadog::Tracing.trace('operations') {
-          @correlation = Datadog::Tracing.correlation
-        }
       end
 
       %w[debug info warn error].each do |level|
         define_method(level) do |log|
-          Datadog::Tracing.trace('operations') {
-            @logger.send(level, log)
-          }
+          @logger.send(level, log)
         end
       end
 
@@ -28,7 +23,6 @@ module LatamLogger
         if msg.is_a?(Hash)
           msg[:level] = severity
           msg[:date] = datetime
-          msg[:"dd.trace_id"] = @correlation.trace_id
         else
           msg = {
             level: severity,

--- a/lib/latam_logger/version.rb
+++ b/lib/latam_logger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module LatamLogger
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
- Remove ddtrace gem dependency from gemspec
- Remove Datadog::Tracing.trace wrapping from log methods
- Remove Datadog::Tracing.correlation and dd.trace_id from log format
- Bump version to 0.2.0